### PR TITLE
add space between alias-list and dashboard-banners

### DIFF
--- a/static/scss/partials/main.scss
+++ b/static/scss/partials/main.scss
@@ -730,6 +730,7 @@ input:focus::placeholder {
 
 .alias-list {
     width: 100%;
+    padding-bottom: 1rem;
 }
 
 .appear-smoothly {


### PR DESCRIPTION
When a free account user don't have any active alias, there's no space between **informtaion footer** and **Upgrade Banner** , but semantically, these are two parts that should have some visual space.

# Screenshot 
1. before ![before](https://user-images.githubusercontent.com/20011366/155844859-f78ae0f9-19dc-41e5-8ead-b9220b1526d2.png)

2. after
![after](https://user-images.githubusercontent.com/20011366/155844874-12d45404-9e7d-4086-9d34-bfb0cbc8b454.png)

# How to test
A free account with no active alias, test the **Upgrade Banner** below **informtaion footer**.


# Checklist

- [x] All acceptance criteria are met.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
